### PR TITLE
Port to tidyselect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
     purrr,
     rlang (>= 0.1),
     gower,
-    RcppRoll
+    RcppRoll,
+    tidyselect
 Suggests:
     testthat,
     magrittr,
@@ -40,3 +41,5 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+Remotes:
+    lionel-/tidyselect@9d0f399

--- a/R/selections.R
+++ b/R/selections.R
@@ -222,64 +222,31 @@ has_selector <- function(x, allowed = selectors) {
 #' info <- summary(rec)
 #' select_terms(info = info, quos(all_predictors()))
 select_terms <- function(info, args) {
-  ## This is a modified version of dplyr:::select_vars
-  
   vars <- info$variable
   roles <- info$role
   types <- info$type
-  
-  if (is_empty(args))
-    stop("At least one selector should be used")
-  
+
+  if (is_empty(args)) {
+    stop("At least one selector should be used", call. = FALSE)
+  }
+
   ## check arguments against whitelist
   lapply(args, check_elements)
-  
+
   # Set current_info so available to helpers
   old_info <- set_current_info(info)
   on.exit(set_current_info(old_info), add = TRUE)
-  # Set current_vars so available to select_helpers
-  old_vars <- tidyselect:::set_current_vars(vars)
-  on.exit(tidyselect:::set_current_vars(old_vars), add = TRUE)
-  
-  # Map variable names to their positions: this keeps integer semantics
-  names_list <- set_names(as.list(seq_along(vars)), vars)
-  
-  # if the first selector is exclusive (negative), start with all columns
-  first <- f_rhs(args[[1]])
-  initial_case <-
-    if (is_negated(first))
-      list(seq_along(vars))
-  else
-    integer(0)
-  
-  # Evaluate symbols in an environment where columns are bound, but
-  # not calls (select helpers are scoped in the calling environment)
-  is_helper <- map_lgl(args, quo_is_helper)
-  ind_list <- map_if(args, is_helper, eval_tidy)
-  ind_list <- map_if(ind_list, !is_helper, eval_tidy, names_list)
-  
-  ind_list <- c(initial_case, ind_list)
-  names(ind_list) <- c(names2(initial_case), names2(args))
-  
-  is_numeric <- map_lgl(ind_list, is.numeric)
-  if (any(!is_numeric))
-    stop("No variables or terms were selected.", call. = FALSE)
-  
-  incl <- tidyselect:::inds_combine(vars, ind_list)
-  
-  # Include/exclude specified variables
-  sel <- set_names(vars[incl], names(incl))
-  
-  # Ensure all output vars named
-  if (is_empty(sel)) {
-    stop("No variables or terms were selected.", call. = FALSE)
-  } else {
-    unnamed <- names2(sel) == ""
-    names(sel)[unnamed] <- sel[unnamed]
-  }
-  
+
+  sel <- with_handlers(tidyselect::vars_select(vars, !!! args),
+    tidyselect_empty = abort_selection
+  )
+
   unname(sel)
 }
+
+abort_selection <- exiting(function(cnd) {
+  abort("No variables or terms were selected.")
+})
 
 #' Role Selection
 #'

--- a/R/selections.R
+++ b/R/selections.R
@@ -238,8 +238,8 @@ select_terms <- function(info, args) {
   old_info <- set_current_info(info)
   on.exit(set_current_info(old_info), add = TRUE)
   # Set current_vars so available to select_helpers
-  old_vars <- dplyr:::set_current_vars(vars)
-  on.exit(dplyr:::set_current_vars(old_vars), add = TRUE)
+  old_vars <- tidyselect:::set_current_vars(vars)
+  on.exit(tidyselect:::set_current_vars(old_vars), add = TRUE)
   
   # Map variable names to their positions: this keeps integer semantics
   names_list <- set_names(as.list(seq_along(vars)), vars)
@@ -265,7 +265,7 @@ select_terms <- function(info, args) {
   if (any(!is_numeric))
     stop("No variables or terms were selected.", call. = FALSE)
   
-  incl <- dplyr:::combine_vars(vars, ind_list)
+  incl <- tidyselect:::inds_combine(vars, ind_list)
   
   # Include/exclude specified variables
   sel <- set_names(vars[incl], names(incl))

--- a/tests/testthat/test_select_terms.R
+++ b/tests/testthat/test_select_terms.R
@@ -1,7 +1,7 @@
 library(testthat)
 library(recipes)
 library(tibble)
-library(dplyr)
+library(tidyselect)
 library(rlang)
 
 data(okc)


### PR DESCRIPTION
Depends on tidyverse/tidyselect#11.

It might make sense to rename `select_terms()` to `terms_select()` and make it take dots, so it's consistent with our general naming and UI schemes. Also, perhaps rename the `info` argument to `terms`. E.g. a function prefixed with `terms_` takes a `terms` object.

`vars_select()` now issue errors about "variables" rather than "columns". Let me know if you need to override any error message, I'll look into signalling typed conditions for those cases as well.