### PR TITLE
Add one hot encoding for step_dummy()

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -20,6 +20,8 @@
 #'  should be used to make a set of full rank dummy variables. See
 #'  [stats::contrasts()] for more details. **not
 #'  currently working**
+#' @param one_hot A logical. For k levels, should k dummy variables be created
+#'  rather than k-1?
 #' @param naming A function that defines the naming convention for
 #'  new dummy columns. See Details below.
 #' @param levels A list that contains the information needed to

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -6,8 +6,8 @@
 \title{Dummy Variables Creation}
 \usage{
 step_dummy(recipe, ..., role = "predictor", trained = FALSE,
-  contrast = options("contrasts"), naming = dummy_names, levels = NULL,
-  skip = FALSE)
+  contrast = options("contrasts"), one_hot = FALSE, naming = dummy_names,
+  levels = NULL, skip = FALSE)
 
 \method{tidy}{step_dummy}(x, ...)
 }
@@ -33,6 +33,9 @@ preprocessing have been estimated.}
 should be used to make a set of full rank dummy variables. See
 \code{\link[stats:contrasts]{stats::contrasts()}} for more details. \strong{not
 currently working}}
+
+\item{one_hot}{A logical. For k levels, should k dummy variables be created
+rather than k-1?}
 
 \item{naming}{A function that defines the naming convention for
 new dummy columns. See Details below.}


### PR DESCRIPTION
Based on #120. I'm not the expert on the formula interface, but based on this [StackOverflow](https://stackoverflow.com/questions/24142576/one-hot-encoding-in-r-categorical-to-dummy-variables) answer, my proposed solution seems to be an accepted way to create one-hot encoding, i.e. using `~ Species - 1`.

Because it was so similar to `step_dummy()`, I thought it would be more natural to add it as an option, rather than create a new `step_one_hot()`. Feel free to tweak as needed or throw out altogether. 

``` r
library(recipes)

recipe(~ Sepal.Width + Species, data = iris) %>%
  step_dummy(Species) %>%
  prep(training = iris) %>%
  bake(newdata = iris)
#> # A tibble: 150 x 3
#>    Sepal.Width Species_versicolor Species_virginica
#>          <dbl>              <dbl>             <dbl>
#>  1        3.50                 0.                0.
#>  2        3.00                 0.                0.
#>  3        3.20                 0.                0.
#>  4        3.10                 0.                0.
#>  5        3.60                 0.                0.
#>  6        3.90                 0.                0.
#>  7        3.40                 0.                0.
#>  8        3.40                 0.                0.
#>  9        2.90                 0.                0.
#> 10        3.10                 0.                0.
#> # ... with 140 more rows

recipe(~ Sepal.Width + Species, data = iris) %>%
  step_dummy(Species, one_hot = TRUE) %>%
  prep(training = iris) %>%
  bake(newdata = iris)
#> # A tibble: 150 x 4
#>    Sepal.Width Species_setosa Species_versicolor Species_virginica
#>          <dbl>          <dbl>              <dbl>             <dbl>
#>  1        3.50             1.                 0.                0.
#>  2        3.00             1.                 0.                0.
#>  3        3.20             1.                 0.                0.
#>  4        3.10             1.                 0.                0.
#>  5        3.60             1.                 0.                0.
#>  6        3.90             1.                 0.                0.
#>  7        3.40             1.                 0.                0.
#>  8        3.40             1.                 0.                0.
#>  9        2.90             1.                 0.                0.
#> 10        3.10             1.                 0.                0.
#> # ... with 140 more rows
```