### PR TITLE
add switch to make second level the reference in step_bin2factor

### DIFF
--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -13,6 +13,8 @@
 #' @param levels A length 2 character string that indicate the
 #'  factor levels for the 1's (in the first position) and the zeros
 #'  (second)
+#' @param ref_first Logical. Should the first level, which replaces
+#' 1's, be the factor reference level?
 #' @param columns A vector with the selected variable names. This
 #'  is `NULL` until computed by [prep.recipe()].
 #' @return An updated version of `recipe` with the new step
@@ -51,6 +53,7 @@ step_bin2factor <-
            role = NA,
            trained = FALSE,
            levels = c("yes", "no"),
+           ref_first = TRUE,
            columns = NULL,
            skip = FALSE) {
     if (length(levels) != 2 | !is.character(levels))
@@ -62,6 +65,7 @@ step_bin2factor <-
         role = role,
         trained = trained,
         levels = levels,
+        ref_first = ref_first,
         columns = columns,
         skip = skip
       )
@@ -73,6 +77,7 @@ step_bin2factor_new <-
            role = NA,
            trained = FALSE,
            levels = NULL,
+           ref_first = NULL,
            columns = NULL,
            skip = FALSE) {
     step(
@@ -81,6 +86,7 @@ step_bin2factor_new <-
       role = role,
       trained = trained,
       levels = levels,
+      ref_first = ref_first,
       columns = columns,
       skip = skip
     )
@@ -98,12 +104,14 @@ prep.step_bin2factor <- function(x, training, info = NULL, ...) {
     role = x$role,
     trained = TRUE,
     levels = x$levels,
+    ref_first = x$ref_first,
     columns = col_names,
     skip = x$skip
   )
 }
 
 bake.step_bin2factor <- function(object, newdata, ...) {
+  levs <- if (object$ref_first) object$levels else rev(object$levels)
   for (i in seq_along(object$columns))
     newdata[, object$columns[i]] <-
       factor(ifelse(
@@ -111,7 +119,7 @@ bake.step_bin2factor <- function(object, newdata, ...) {
         object$levels[1],
         object$levels[2]
       ),
-      levels = object$levels)
+      levels = levs)
   newdata
 }
 

--- a/tests/testthat/test_bin2factor.R
+++ b/tests/testthat/test_bin2factor.R
@@ -36,3 +36,12 @@ test_that('printing', {
   expect_output(prep(rec2, training = covers, verbose = TRUE))
 })
 
+
+test_that('choose reference level', {
+  rec4 <- rec %>% step_bin2factor(rocks, ref_first = FALSE)
+  rec4 <- prep(rec4, training = covers)
+  res4 <- bake(rec4, newdata = covers)
+  expect_true(all(res4$rocks[res4$more_rocks == 1] == "yes"))
+  expect_true(all(res4$rocks[res4$more_rocks == 0] == "no"))
+  expect_true(levels(res4$rocks)[1] == "no")
+})


### PR DESCRIPTION
First stab at addressing #141. I wrote the test differently than the others in the file because `table` orders by factor levels and I wanted to be explicit about what's being tested here.

