### PR TITLE
Feature `one_hot` argument for `step_dummy()`

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -78,6 +78,20 @@
 #' unique(okc$diet)
 #' grep("^diet", names(dummy_data), value = TRUE)
 #'
+#' # Obtain the full set of dummy variables using `one_hot` option
+#' rec %>%
+#'   step_dummy(diet, one_hot = TRUE) %>%
+#'   prep(training = okc, retain = TRUE) %>%
+#'   juice(starts_with("diet")) %>%
+#'   names() %>%
+#'   length()
+#'
+#' length(unique(okc$diet))
+#'
+#' # Without one_hot
+#' length(grep("^diet", names(dummy_data), value = TRUE))
+#'
+#'
 #' tidy(dummies, number = 1)
 
 
@@ -217,7 +231,7 @@ bake.step_dummy <- function(object, newdata, ...) {
     on.exit(expr = NULL)
 
     if(!object$one_hot) {
-      indicators <- indicators[, -1, drop = FALSE]
+      indicators <- indicators[, colnames(indicators) != "(Intercept)", drop = FALSE]
     }
 
     ## use backticks for nonstandard factor levels here

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -20,6 +20,8 @@
 #'  should be used to make a set of full rank dummy variables. See
 #'  [stats::contrasts()] for more details. **not
 #'  currently working**
+#' @param one_hot A logical. For k levels, should k dummy variables be created
+#' rather than k-1?
 #' @param naming A function that defines the naming convention for
 #'  new dummy columns. See Details below.
 #' @param levels A list that contains the information needed to
@@ -85,6 +87,7 @@ step_dummy <-
            role = "predictor",
            trained = FALSE,
            contrast = options("contrasts"),
+           one_hot = FALSE,
            naming = dummy_names,
            levels = NULL,
            skip = FALSE) {
@@ -95,6 +98,7 @@ step_dummy <-
         role = role,
         trained = trained,
         contrast = contrast,
+        one_hot = one_hot,
         naming = naming,
         levels = levels,
         skip = skip
@@ -107,6 +111,7 @@ step_dummy_new <-
            role = "predictor",
            trained = FALSE,
            contrast = contrast,
+           one_hot = one_hot,
            naming = naming,
            levels = levels,
            skip = FALSE
@@ -117,6 +122,7 @@ step_dummy_new <-
       role = role,
       trained = trained,
       contrast = contrast,
+      one_hot = one_hot,
       naming = naming,
       levels = levels,
       skip = skip
@@ -144,7 +150,11 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   levels <- vector(mode = "list", length = length(col_names))
   names(levels) <- col_names
   for (i in seq_along(col_names)) {
-    form <- as.formula(paste0("~", col_names[i]))
+    form_chr <- paste0("~", col_names[i])
+    if(x$one_hot) {
+      form_chr <- paste0(form_chr, "-1")
+    }
+    form <- as.formula(form_chr)
     terms <- model.frame(form,
                          data = training,
                          xlev = x$levels[[i]])
@@ -165,6 +175,7 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     role = x$role,
     trained = TRUE,
     contrast = x$contrast,
+    one_hot = x$one_hot,
     naming = x$naming,
     levels = levels,
     skip = x$skip
@@ -205,7 +216,10 @@ bake.step_dummy <- function(object, newdata, ...) {
     options(na.action = old_opt)
     on.exit(expr = NULL)
 
-    indicators <- indicators[, -1, drop = FALSE]
+    if(!object$one_hot) {
+      indicators <- indicators[, -1, drop = FALSE]
+    }
+
     ## use backticks for nonstandard factor levels here
     used_lvl <- gsub(paste0("^", col_names[i]), "", colnames(indicators))
     colnames(indicators) <- object$naming(col_names[i], used_lvl, fac_type == "ordered")

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -106,6 +106,20 @@ dummy_data <- bake(dummies, newdata = okc)
 unique(okc$diet)
 grep("^diet", names(dummy_data), value = TRUE)
 
+# Obtain the full set of dummy variables using `one_hot` option
+rec \%>\%
+  step_dummy(diet, one_hot = TRUE) \%>\%
+  prep(training = okc, retain = TRUE) \%>\%
+  juice(starts_with("diet")) \%>\%
+  names() \%>\%
+  length()
+
+length(unique(okc$diet))
+
+# Without one_hot
+length(grep("^diet", names(dummy_data), value = TRUE))
+
+
 tidy(dummies, number = 1)
 }
 \seealso{

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -6,8 +6,8 @@
 \title{Dummy Variables Creation}
 \usage{
 step_dummy(recipe, ..., role = "predictor", trained = FALSE,
-  contrast = options("contrasts"), naming = dummy_names, levels = NULL,
-  skip = FALSE)
+  contrast = options("contrasts"), one_hot = FALSE, naming = dummy_names,
+  levels = NULL, skip = FALSE)
 
 \method{tidy}{step_dummy}(x, ...)
 }
@@ -33,6 +33,9 @@ preprocessing have been estimated.}
 should be used to make a set of full rank dummy variables. See
 \code{\link[stats:contrasts]{stats::contrasts()}} for more details. \strong{not
 currently working}}
+
+\item{one_hot}{A logical. For k levels, should k dummy variables be created
+rather than k-1?}
 
 \item{naming}{A function that defines the naming convention for
 new dummy columns. See Details below.}


### PR DESCRIPTION
Since I sadly deleted the PR #136 branch with `one_hot`, I could not reopen it and have reimplemented it here, incorporating your comments from there. 

I have not removed the `contrasts` argument, as I feel that is a separate feature.